### PR TITLE
Use newer azurerm provider for channel upgrades

### DIFF
--- a/generators/app/templates/acr-build&publish/01-provider.tf
+++ b/generators/app/templates/acr-build&publish/01-provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "=3.0.0"
+      version = "=3.71.0"
     }
   }
 }

--- a/generators/app/templates/acr/01-provider.tf
+++ b/generators/app/templates/acr/01-provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "=3.0.0"
+      version = "=3.71.0"
     }
   }
 }

--- a/generators/app/templates/aks/01-provider.tf
+++ b/generators/app/templates/aks/01-provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source = "hashicorp/azurerm"
-      version = "=3.0.0"
+      version = "=3.71.0"
     }
   }
 }

--- a/generators/app/templates/istio-monitoring/provider.tf
+++ b/generators/app/templates/istio-monitoring/provider.tf
@@ -9,7 +9,7 @@ terraform {
 <%_ if (cloudProvider == "azure") { _%>
    azurerm = {
       source = "hashicorp/azurerm"
-      version = "=3.0.0"
+      version = "=3.71.0"
     }
 <%_ } _%>
 <%_ if ( domain == "" ) { _%>


### PR DESCRIPTION
`automatic_channel_upgrade` and `node_os_channel_upgrade` parameters are added in newer version of azure terraform provider. Their default value is None. Other options are in preview stage. Will use Patch or NodeImage once they are GA.

More information can be found here: https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-image